### PR TITLE
Merge core/v7.0 into unity/v5.0 (Conflicts)

### DIFF
--- a/docs/cli/guides/configuration.md
+++ b/docs/cli/guides/configuration.md
@@ -78,7 +78,7 @@ The Beamable CLI executes as a local dotnet tool installation. That means that t
 ```
 
 !!! info "The folder can exist in a higher folder."
-    
+
     Normally the `.config/` folder exists as a sibling of the `.beamable/` folder. However, the `.config/` folder _may_ exist in a parent folder. The closest `.config/` folder will be used. See the [dotnet tool documentation](https://learn.microsoft.com/en-us/dotnet/core/tools/local-tools-how-to-use) for more information. 
 
 


### PR DESCRIPTION
The core/v7.0 branch was unable to merge into unity/v5.0. Please review the changes.