### PR TITLE
Merge core/v7.0 into unity/v5.0 (Conflicts)

### DIFF
--- a/.github/workflows/auto-publish-branch.yml
+++ b/.github/workflows/auto-publish-branch.yml
@@ -135,7 +135,8 @@ jobs:
         run: mike deploy "${{ steps.version.outputs.mike_alias }}" --branch gh-pages --push
 
       - name: Notify Slack
-        if: steps.check.outputs.published == 'true' 
+        # if: steps.check.outputs.published == 'true' 
+        if: false
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DOCS_CHANNEL_URL }}
           MIKE_ALIAS: ${{ steps.version.outputs.mike_alias }}

--- a/.github/workflows/auto-sync-core.yml
+++ b/.github/workflows/auto-sync-core.yml
@@ -42,14 +42,9 @@ jobs:
 
           # Try a normal squash merge
           if git merge origin/${{ github.ref_name }} --squash; then
-              if ! git diff --quiet; then
-                  git commit -m "Squash merge ${{ github.ref_name }} into ${{ matrix.branch }}"
-                  git push origin ${{ matrix.branch }}
-                  echo "status=success" >> $GITHUB_OUTPUT
-              else
-                  echo "No changes to commit"
-                  echo "status=no_changes" >> $GITHUB_OUTPUT
-              fi
+                git commit -m "Squash merge ${{ github.ref_name }} into ${{ matrix.branch }}"
+                git push origin ${{ matrix.branch }}
+                echo "status=success" >> $GITHUB_OUTPUT
           else
               # Merge conflict: retry with 'theirs'
               git reset --hard HEAD
@@ -116,8 +111,8 @@ jobs:
           PR_URLS: ${{ needs.merge_branches.outputs.conflict_pr_urls }}
         run: |
           # If both are empty, do nothing
-          if [ -z "$SUCCESS" ] && [ -z "$CONFLICT" ]; then
-            echo "No successes or conflicts — skipping Slack notification."
+          if [ -z "$CONFLICT" ]; then
+            echo "No conflicts — skipping Slack notification."
             exit 0
           fi
 

--- a/docs/cli/guides/getting-started.md
+++ b/docs/cli/guides/getting-started.md
@@ -6,7 +6,8 @@ The Beamable CLI is a dotnet tool that allows developers to interact with Beamab
 You'll need to install [Dotnet 10](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) before you can get started. 
 Verify it is installed by running `dotnet --version` from a terminal.
 
-!!! info We support Dotnet 8 as well.
+!!! info "We support Dotnet 8 as well."
+
     If you are using the Beamable CLI before version 7.0, then you should be using [Dotnet 8](https://dotnet.microsoft.com/en-us/download/dotnet/8.0). Starting with CLI 7.0 and beyond, we support both versions of dotnet, but we recommend you use `net10.0`. 
 
 ## Installing


### PR DESCRIPTION
The core/v7.0 branch was unable to merge into unity/v5.0. Please review the changes.