### PR TITLE
Merge core/v7.0 into unreal/v2.3 (Conflicts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Beamable Docs Repository
 
-This is the `core/v7.0` branch.
-
 If you have MkDocs installed, you can host these docs locally.
 
 ```


### PR DESCRIPTION
The core/v7.0 branch was unable to merge into unreal/v2.3. Please review the changes.