### PR TITLE
Content page updates to help guide customers upgrading from 2.x

### DIFF
--- a/docs/unity/user-reference/beamable-services/profile-storage/content/content-unity.md
+++ b/docs/unity/user-reference/beamable-services/profile-storage/content/content-unity.md
@@ -405,12 +405,25 @@ Each content JSON file contains a `referenceManifestId` representing its last sy
 - Identifying potential conflicts
 - Maintaining synchronization integrity
 
+### Why `.beamable/local/` Is Gitignored
+
+The SDK adds the following entries to `.beamable/.gitignore`:
+
+```
+temp/**/*
+local/**/*
+```
+
+The `local/**/*` entry intentionally excludes `.beamable/local/` from Git. Because `referenceManifestId` is updated on every publish, even a single publish touches every content JSON file — producing frequent, low-signal commits. For Git-friendly content tracking, use **Content Snapshots** instead (see the Snapshot button in Beam Content).
+
+You can track the raw local JSON files in Git by removing `local/**/*` from your `.gitignore`, but this is not recommended unless your team is comfortable with the resulting commit noise.
+
 ### Version Control Best Practices
 
 1. **Minimize Unnecessary Commits**
    - Avoid committing files when only the referenceManifestId has changed
    - These changes can safely be reverted if needed
-2. **Handling Revert Operations**  
+2. **Handling Revert Operations**
    Reverting to an older version will trigger conflict detection (due to mismatched `referenceManifestId`). To resolve while preserving your content changes, run:
    ```shell
    beam content resolve --use local
@@ -422,4 +435,11 @@ Each content JSON file contains a `referenceManifestId` representing its last sy
 
 While each content object inherits from Unity's [ScriptableObject](https://docs.unity3d.com/Manual/class-ScriptableObject.html), these objects exist solely in memory for Unity Editor inspection and are not saved to disk.
 
-The actual content data is stored as JSON files in your project's: `.beamable/content/<YOUR_PID>/global/` directory
+The actual content data is stored as JSON files under `.beamable/` in two locations:
+
+| Location | Contents |
+| --- | --- |
+| `.beamable/content/<YOUR_PID>/global/` | Most recently **synchronized remote content** — reflects what is currently published to the realm |
+| `.beamable/local/content/<YOUR_PID>/global/` | **Local working copy** — may include work-in-progress changes that have not yet been published |
+
+When you switch realms and synchronize using Beam Content, both folders are populated with the content for that realm.

--- a/docs/unity/whatsnew/3.1.md
+++ b/docs/unity/whatsnew/3.1.md
@@ -58,7 +58,9 @@ Changed
 
 ### Upgrading from SDK 2.x
 
-- **Remove** `Assets/Beamable/Resources/content/` from Git — this folder is no longer the source of truth for content.
+When upgrading from 2.x, in addition to the standard migration, you may want to consider the following Git changes:
+
+- Stop committing `Assets/Beamable/Resources/content/` to Git — this folder is no longer the source of truth for content.
 - Content is now stored as JSON files under `.beamable/`:
     - `.beamable/content/<realm>/` — most recently synchronized remote content.
     - `.beamable/local/content/<realm>/` — local working copy, may contain unpublished changes.

--- a/docs/unity/whatsnew/3.1.md
+++ b/docs/unity/whatsnew/3.1.md
@@ -43,6 +43,10 @@ Changed
 Added
 
 - [Unity] Support to CLI Snapshot management on Content editor.
+    - Snapshots capture the entire content state of a realm as a single JSON file, making them suitable for Git.
+    - Automatic snapshots can be written to `.beamable/local/` (default, gitignored) or `.beamable/shared/` (not gitignored).
+    - Configure snapshot destination in **Project Settings → Beamable → Content → On Publish Auto Snapshot Type** (`None` / `Local Only` / `Shared Only` / `Both`).
+    - To track content in Git, set the snapshot type to `Shared Only` or `Both` and commit `.beamable/shared/`.
 
 Fixed
 
@@ -51,3 +55,12 @@ Fixed
 Changed
 
 - [Unity] Updated Microservices configuration Federation list to a view-mode only. Now federation are listed based on the OpenApi specification generated from the Microservices. So no need to previously add Federation Id to a Federation Interface on Unity.
+
+### Upgrading from SDK 2.x
+
+- **Remove** `Assets/Beamable/Resources/content/` from Git — this folder is no longer the source of truth for content.
+- Content is now stored as JSON files under `.beamable/`:
+    - `.beamable/content/<realm>/` — most recently synchronized remote content.
+    - `.beamable/local/content/<realm>/` — local working copy, may contain unpublished changes.
+- `.beamable/local/` is gitignored by default (see `.beamable/.gitignore`). Raw content JSON files change on every publish due to `referenceManifestId` updates, making them too noisy for direct Git tracking. Use Snapshots instead.
+- **Realm-to-realm promotion:** publish from Unity to your Dev realm, then promote to Staging and Production via the Beamable web portal.


### PR DESCRIPTION
Added some additional explanation about content storage:
- clarified the difference between `.beamable/content/` and `.beamable/local/content/`
- added some instructions in an upgrade section in the 3.1 "What's New" page