### PR TITLE
Docs: cli `beam local` commands

### DIFF
--- a/docs/cli/SUMMARY.md
+++ b/docs/cli/SUMMARY.md
@@ -15,6 +15,10 @@
     - [Logging](guides/ms-logging.md)
     - [Command Line Output](guides/ms-command-line.md)
     - [Troubleshooting](guides/ms-troubleshooting.md)
+- Local Backend Development
+    - [Overview](guides/local-backend-overview.md)
+    - [Setup and Dependencies](guides/local-backend-setup.md)
+    - [Running Tools](guides/local-backend-tools.md)
 - Beam CLI Commands
     - [Commands Overview](commands/cli-command-reference.md)
     - [Commands Reference](commands/cli-command-reference/)

--- a/docs/cli/commands/cli-command-reference.md
+++ b/docs/cli/commands/cli-command-reference.md
@@ -8,3 +8,18 @@ All of the Beam CLI commands are available in the left navigation bar. This tabl
 | [Config](cli-command-reference/config/config.md)     | `beam config` helps you verify your current Beamable project in the CLI |
 | [Login](cli-command-reference/login.md)       | `beam login` helps you manage access tokens for use in the CLI          |
 | [Project](cli-command-reference/project/project.md)   | `beam project` helps you create and use Standalone Microservices        |
+| [Local](cli-command-reference/local/local.md) | `beam local` commands for managing local backend development             |
+
+## Global Options
+
+The following options are available for all Beam CLI commands:
+
+### Java Path
+The `--java-path` option allows you to specify a custom location for Java 8, which is required for local backend development commands.
+
+- **Flag**: `--java-path`
+- **Default**: The CLI attempts to resolve Java through common install locations
+- **Environment Variable**: `BEAM_JAVA_EXE` 
+- **Description**: Points to the Java 8 executable needed to run backend tools and utilities
+
+Example:

--- a/docs/cli/commands/cli-command-reference/SUMMARY.md
+++ b/docs/cli/commands/cli-command-reference/SUMMARY.md
@@ -55,6 +55,17 @@
 - listen
 	- [player](listen/player.md)
 	- [server](listen/server.md)
+- local
+	- [audit-realm-config](local/audit-realm-config.md)
+	- [compile](local/compile.md)
+	- [inspect](local/inspect.md)
+	- [list-tools](local/list-tools.md)
+	- [logs](local/logs.md)
+	- [ps](local/ps.md)
+	- [run](local/run.md)
+	- [set-local-vars](local/set-local-vars.md)
+	- [stop](local/stop.md)
+	- [validate](local/validate.md)
 - [login](login.md)
 - [logout](logout.md)
 - [me](me.md)


### PR DESCRIPTION
Documentation updates for [cli `beam local` commands](https://github.com/beamable/BeamableProduct/pull/4258) (#4258).

Generated by docNerd.
