### PR TITLE
Docs: cli `beam local` commands

### DIFF
--- a/docs/cli/SUMMARY.md
+++ b/docs/cli/SUMMARY.md
@@ -18,3 +18,6 @@
 - Beam CLI Commands
     - [Commands Overview](commands/cli-command-reference.md)
     - [Commands Reference](commands/cli-command-reference/)
+- Local Backend Development
+    - [Getting Started](local/getting-started.md)
+    - [Local Commands](local/local-commands.md)

--- a/docs/cli/commands/cli-command-reference.md
+++ b/docs/cli/commands/cli-command-reference.md
@@ -8,3 +8,17 @@ All of the Beam CLI commands are available in the left navigation bar. This tabl
 | [Config](cli-command-reference/config/config.md)     | `beam config` helps you verify your current Beamable project in the CLI |
 | [Login](cli-command-reference/login.md)       | `beam login` helps you manage access tokens for use in the CLI          |
 | [Project](cli-command-reference/project/project.md)   | `beam project` helps you create and use Standalone Microservices        |
+| [Local](cli-command-reference/local/local.md)         | `beam local` manages local backend development environment               |
+
+## Local Backend Development
+
+The `beam local` command suite provides tools for running and managing the Beamable backend locally. This enables faster development cycles by running backend services on your development machine.
+
+Key local development commands:
+- `beam local run` - Start local backend services  
+- `beam local ps` - View running service status
+- `beam local stop` - Stop running services
+- `beam local logs` - View service logs
+- `beam local validate` - Check system dependencies
+
+See the [Local Commands Reference](cli-command-reference/local/) for complete details.

--- a/docs/cli/commands/cli-command-reference/SUMMARY.md
+++ b/docs/cli/commands/cli-command-reference/SUMMARY.md
@@ -55,6 +55,17 @@
 - listen
 	- [player](listen/player.md)
 	- [server](listen/server.md)
+- local
+	- [audit-realm-config](local/audit-realm-config.md)
+	- [compile](local/compile.md)
+	- [inspect](local/inspect.md)
+	- [list-tools](local/list-tools.md)
+	- [logs](local/logs.md)
+	- [ps](local/ps.md)
+	- [run](local/run.md)
+	- [set-local-vars](local/set-local-vars.md)
+	- [stop](local/stop.md)
+	- [validate](local/validate.md)
 - [login](login.md)
 - [logout](logout.md)
 - [me](me.md)


### PR DESCRIPTION
Documentation updates for [cli `beam local` commands](https://github.com/beamable/BeamableProduct/pull/4258) (#4258).

Generated by docNerd.
