### PR TITLE
copyedit: prose polish for core/v7.0 shared files

### DIFF
--- a/docs/cli/guides/configuration.md
+++ b/docs/cli/guides/configuration.md
@@ -42,7 +42,7 @@ mainFolder % dotnet beam config
  } 
 ```
 
-However, if the `beam config` command was invoked from the `someOtherFolder` path, you should expect to see an error, because there is no `.beamable` folder within the parent linear. 
+However, if the `beam config` command was invoked from the `someOtherFolder` path, you should expect to see an error, because there is no `.beamable` folder within the parent lineage. 
 
 ```sh
 someOtherFolder % dotnet beam config

--- a/docs/cli/guides/getting-started.md
+++ b/docs/cli/guides/getting-started.md
@@ -30,9 +30,9 @@ The following command will install the latest CLI. The "latest" string can be an
 beam version install latest
 ```
 
-!!! info "Check Versions on Nuget"
+!!! info "Check Versions on NuGet"
 
-    Remember, Beamable.Tools is a dotnet tool available through Nuget. As such, you can find all available versions at [nuget.org](https://www.nuget.org/packages/Beamable.Tools)
+    Remember, Beamable.Tools is a dotnet tool available through NuGet. You can find all available versions at [nuget.org](https://www.nuget.org/packages/Beamable.Tools)
 
 There may be updates you are required to do, so please check the [migration guide](upgrading.md).
 

--- a/docs/cli/guides/ms-command-line.md
+++ b/docs/cli/guides/ms-command-line.md
@@ -96,7 +96,7 @@ dotnet beam config | jq '.data.cid'
 "123"
 ```
 
-Sometimes it is important to get the unescaped JSON, so the `fromjson` component of JQ can be used. For example, if we wanted the `cid` value, but without quotes, 
+Sometimes you need the unescaped JSON; the `fromjson` component of JQ can be used. For example, if we wanted the `cid` value, but without quotes, 
 
 ```sh
 dotnet beam config | jq '.data.cid | fromjson'

--- a/docs/cli/guides/ms-logging.md
+++ b/docs/cli/guides/ms-logging.md
@@ -56,7 +56,7 @@ Each log has a _level_, or an _importance_ rating. Logs are one of the following
 - _Debug_
 - _Verbose_
 
-When you run a Microservice locally, you will see log messages at the _Debug_ level and above. However, in a deployed Microservice, you will only see **Information** and above. This is called the _Log Level_. It is considered best practice to avoid logging _Debug_ and _Verbose_ logs in production, because they negatively impact performance. 
+When you run a Microservice locally, you will see log messages at the _Debug_ level and above. However, in a deployed Microservice, you will only see **Information** and above. This is called the _Log Level_. Best practice is to avoid logging _Debug_ and _Verbose_ logs in production, as they negatively impact performance. 
 
 The `Log` type has methods for each type of log level.
 
@@ -93,7 +93,7 @@ However, the attribute, `a`, is available for querying in Portal. Use a custom s
 
 #### Scoped Custom Attributes
 
-It is possible to automatically add attributes to an entire sequence of logs. For example, imagine you wanted to tag a series of log lines as being part of an algorithm.
+You can automatically add attributes to an entire sequence of logs. For example, imagine you wanted to tag a series of log lines as being part of an algorithm.
 
 ```csharp
 [ClientCallable]
@@ -214,7 +214,7 @@ There are several standard log attributes that will be included automatically. S
 
 ### Third Party Log Hosting
 
-Starting with version 6.0, it is possible to send Microservice logs to a third parties. In this example, we will use  BetterStack.
+Starting with version 6.0, you can send Microservice logs to third-party log hosting services. In this example, we will use BetterStack.
 
 This section will assume you have set up a BetterStack account, and created a _Source_ such that you have a _source token_ and an _ingesting host_. 
 

--- a/docs/cli/guides/ms-routing.md
+++ b/docs/cli/guides/ms-routing.md
@@ -73,7 +73,7 @@ var scope = cid + '.' + pid;
 ```
 #### Authorization 
 
-Finally, while not required, it is important to send an HTTP authorization header in the form of a Bearer token. The bearer token should be a valid access token for a Beamable Player. These tokens can be fetched from the Portal, or you can use the following command to view the token information from a local beamable CLI project. 
+Finally, while not required, we recommend sending an HTTP authorization header in the form of a Bearer token. The bearer token should be a valid access token for a Beamable Player. These tokens can be fetched from the Portal, or you can use the following command to view the token information from a local beamable CLI project. 
 
 ```sh
 cat .beamable/temp/auth.beam.json
@@ -132,7 +132,7 @@ The automatic client code generation can be disabled when a project builds by mo
 
 ### Open API
 
-It is possible to use the project oapi command to generate an Open API document and then use open source tools to transpile the document into a client in some other programming language.
+You can use the project oapi command to generate an Open API document and then use open source tools to transpile the document into a client in some other programming language.
 
 ```sh
 dotnet beam project oapi --output example.json --ids MyService

--- a/docs/cli/guides/ms-workflow.md
+++ b/docs/cli/guides/ms-workflow.md
@@ -91,7 +91,7 @@ When a service is stopped this way, you should expect to see a log in the Micros
 
 ## Observing Logs
 
-When a service is run, the process that starts the service should receive the log outputs. For example, if the service is run through the IDE, then the IDE should receive the logs from the service. However, it is possible to attach to the logs of a running service from a separate process. 
+When a service is run, the process that starts the service should receive the log outputs. For example, if the service is run through the IDE, then the IDE should receive the logs from the service. However, you can attach to the logs of a running service from a separate process. 
 
 For example, imagine that a service is run through `dotnet` directly,
 

--- a/docs/cli/guides/upgrading.md
+++ b/docs/cli/guides/upgrading.md
@@ -134,7 +134,7 @@ generated when the Microservices were built. However, in CLI 5+, the engine inte
 are responsible for generating the client code, and the default behaviour is that a standalone
 Microservice project will _no longer generate client code automatically_.
 
-It is possible to generate a unity client by hand using the following command,
+You can generate a Unity client by hand using the following command,
 ```sh
 dotnet beam project generate-client-oapi --output-dir ./Path/To/Your/Unity/Folder/To/Put/Clients/In
 ```

--- a/docs/cli/guides/upgrading.md
+++ b/docs/cli/guides/upgrading.md
@@ -162,9 +162,7 @@ releases.
 
 #### Removed `net6.0` and `net7.0` support
 Unfortunately, `net6.0` and `net7.0` have reached their [End-Of-Life phases](https://devblogs.microsoft.com/dotnet/dotnet-6-end-of-support/). 
-The CLI 4.0 release officially drops Beamable support for these EOL dotnet 
-versions. As such, when you update your projects, you must update your
-`.csproj` files to use `net8.0`. 
+The CLI 4.0 release officially drops Beamable support for these EOL .NET versions; when you update your projects, you must update your `.csproj` files to use `net8.0`. 
 
 In all your `.csproj` files, find the line with the `<TargetFramework>` 
 declaration, 

--- a/docs/portal/campaigns.md
+++ b/docs/portal/campaigns.md
@@ -16,7 +16,7 @@ Beamable Portal, under **Communicate > Campaigns > + Create Campaign.**
 
 After that, you can create campaigns setting some information through a few steps:
 
-- Meta information: This is going to be all the main information about your Campaign. You're going to select which Type the campaign will be, as well as it's name and date.
+- Meta information: This is going to be all the main information about your Campaign. You're going to select which Type the campaign will be, as well as its name and date.
 
 ![Campaign Meta Information](../media/imgs/campaigns-meta-information.png)
 


### PR DESCRIPTION
## Summary

Mirrors copyediting work already applied to `unity/v5.0` across all files shared with `core/v7.0` via the auto-sync workflow. Without this PR, a future push to `core/v7.0` could overwrite these fixes in `unity/v5.0`.

Changes across 26 files include:

- **Grammar fixes:** `its` vs `it's`, missing verb ("interface reconfigured"), word order ("will first be saved"), "parent linear" → "parent lineage"
- **Passive voice / agency:** "it is possible to" → "you can"; "it is recommended to" → "we recommend"; "it is considered best practice" → "Best practice is to"
- **Connective cleanup:** "As such" replaced with "Thus,", "so", "meaning they share", or restructured away entirely
- **Terminology:** NuGet capitalization; "dotnet versions" → ".NET versions"; "webGL" → "WebGL"; "query args" → "query parameters"
- **Prose tightening:** cloud-save.md paragraph rewrite; `CommerceService.Purchase()` named explicitly; `ISimFaultHandler` sentence consolidated; Lightbeam title case; hats.md boilerplate removed; connectivity.md "false negatives" → "spurious disconnection reports"
- **Note admonition:** `inventory-overview.md` standardized to `_Note_:` format; `groups.md` patronizing admonition replaced with inline note

## Test plan

- [ ] Verify `mkdocs build` passes on `core/v7.0` after merge
- [ ] Spot-check a few pages in local `mkdocs serve`
- [ ] Confirm auto-sync to `unity/v5.0` does not regress these fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)