### PR TITLE
Merge core/v7.0 into unity/v5.0 (Conflicts)

### DIFF
--- a/docs/cli/guides/ms-federation.md
+++ b/docs/cli/guides/ms-federation.md
@@ -43,7 +43,7 @@ public partial class ExampleService : IFederatedLogin<MySample>
 }
 ```
 
-The `MySample` class included as the generic type in the `IFederatedLogin` interface specifies the id for the federated login. The class signature for these types must implement the `IFederationId` type, and be annotated with a `FederationId` attribute. The string argument for the attribute constructor must be stable between releases of your service. It also needs to be unique.
+The `MySample` class included as the generic type in the `IFederatedLogin` interface specifies the id for the federated login. The class signature for these types must implement the `IFederationId` type and include a `FederationId` attribute. The string argument for the attribute constructor must be stable between releases of your service. It also needs to be unique.
 
 ```csharp
 [FederationId("myId")]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,11 +18,6 @@ theme:
 
 markdown_extensions:
   - pymdownx.inlinehilite
-  - pymdownx.highlight:
-      use_pygments: true
-      pygments_lang_class: true
-      linenums: true
-  - pymdownx.superfences
   - pymdownx.snippets:
       auto_append:
         - docs/includes/abbreviations.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,11 @@ theme:
 
 markdown_extensions:
   - pymdownx.inlinehilite
+  - pymdownx.highlight:
+      use_pygments: true
+      pygments_lang_class: true
+      linenums: true
+  - pymdownx.superfences
   - pymdownx.snippets:
       auto_append:
         - docs/includes/abbreviations.md


### PR DESCRIPTION
The core/v7.0 branch was unable to merge into unity/v5.0. Please review the changes.