### PR TITLE
Add Microservice Analytics how-to guide

### DIFF
--- a/docs/cli/SUMMARY.md
+++ b/docs/cli/SUMMARY.md
@@ -13,6 +13,7 @@
     - [CLI Workflows](guides/ms-workflow.md)
     - [UPM](guides/ms-upm.md)
     - [Logging](guides/ms-logging.md)
+    - [Analytics](guides/ms-analytics.md)
     - [Command Line Output](guides/ms-command-line.md)
     - [Troubleshooting](guides/ms-troubleshooting.md)
 - Beam CLI Commands

--- a/docs/cli/guides/ms-analytics.md
+++ b/docs/cli/guides/ms-analytics.md
@@ -1,0 +1,73 @@
+# Microservice Analytics
+
+Emit custom analytics events from a Beamable Standalone Microservice.
+
+## Dependencies
+
+This guide assumes you have an existing Microservice. You need to complete the
+[Getting-Started Guide](getting-started.md). That means having [.NET 10](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) installed, and getting the [Beam CLI](https://www.nuget.org/packages/Beamable.Tools).
+
+You can confirm you have everything installed by checking the versions of the tools.
+```sh
+dotnet --version
+dotnet beam version # dotnet beam --version also works.
+```
+
+In order to emit analytics events, you also need to have a local `.beamable/` workspace with a Beamable Standalone Microservice. As a reminder, you can create one quickly using the commands below.
+```sh
+beam init MyProject
+cd MyProject
+dotnet beam project new service HelloWorld
+```
+
+## Emitting Events
+
+Microservices can emit custom analytics events using the `Services.Analytics` API.
+
+Define a subclass of `CoreEvent` to describe your event. The constructor takes a category string, a snake_case event name, and a flat payload dictionary.
+
+```csharp
+using System.Collections.Generic;
+using Beamable.Api.Analytics;
+
+public class MatchResultEvent : CoreEvent
+{
+    public MatchResultEvent(string outcome, int score)
+        : base("gameplay", "match_result", new Dictionary<string, object>
+        {
+            ["outcome"] = outcome,
+            ["score"] = score,
+        })
+    {
+    }
+}
+```
+
+Then build and send the event from a callable method using `Services.Analytics`:
+
+```csharp
+[ClientCallable]
+public async Task<string> RecordMatchResult(string outcome, int score)
+{
+    var evt = new MatchResultEvent(outcome, score);
+    var request = Services.Analytics.BuildRequest(evt);
+    Services.Analytics.SendAnalyticsEvent(request);
+    return "OK";
+}
+```
+
+### Source Domain
+
+The Microservice analytics API uses the same channel as client-side telemetry. Events emitted from a Microservice therefore appear as **client** records in Athena, not as a separate server or game source.
+
+The Athena table name follows the pattern `client_{category}_{event_name}`. For the example above, the table is `client_gameplay_match_result`.
+
+### Verifying Events
+
+After invoking your Microservice method, the event should appear in Athena within a few minutes. You can confirm it with a query like:
+
+```sql
+SELECT * FROM client_gameplay_match_result LIMIT 10;
+```
+
+Individual player analytics events are also visible on the player profile page in the Beamable Portal.

--- a/docs/cli/guides/ms-analytics.md
+++ b/docs/cli/guides/ms-analytics.md
@@ -43,6 +43,8 @@ public class MatchResultEvent : CoreEvent
 }
 ```
 
+Keep the number of distinct categories small - a handful such as `"gameplay"`, `"funnel"`, and `"monetization"` is typical. Event names within a category can be more numerous; a single `"gameplay"` category might contain many sibling event types beyond just `"match_result"`.
+
 Then build and send the event from a callable method using `Services.Analytics`:
 
 ```csharp


### PR DESCRIPTION
## Summary

- Adds `docs/cli/guides/ms-analytics.md`: a How-To guide explaining how to emit custom analytics events from a Beamable Standalone Microservice using `CoreEvent` and `Services.Analytics`
- Adds `[Analytics](guides/ms-analytics.md)` to `docs/cli/SUMMARY.md` between Logging and Command Line Output

## Test plan

- [ ] Verify the new page renders correctly in MkDocs preview
- [ ] Confirm the nav entry appears in the Microservices section between Logging and Command Line Output
- [ ] Check that code blocks render with correct syntax highlighting

## Propagation

### core/v7.1 - cherry-pick

After this PR is merged, cherry-pick the commit onto `core/v7.1`:

```sh
git checkout core/v7.1
git cherry-pick 32cd414832da18dde63dc92498ac309d5456a563
git push
```

If the branch has diverged enough to cause a conflict, the change is small: one new file (`docs/cli/guides/ms-analytics.md`) and one added line in `docs/cli/SUMMARY.md`.

### unity/v5.0 and unity/v5.1 - manual BI link

The Unity SDK docs have a Business Intelligence analytics overview page that should link to this new guide. Apply the following change to `docs/unity/user-reference/beamable-services/bi/analytics-overview.md` in both the `unity/v5.0` and `unity/v5.1` branches:

```diff
 | Game Server | Analytics event came from the multiplayer server | Yes | Upon Request |
 
+Beamable Microservices can also emit custom analytics events. Events sent via the Microservice analytics API use the same channel as client-side telemetry and appear as **client** records. See [Microservice Analytics](../../../../cli/guides/ms-analytics.md).
+
 ## Analytics Events vs Stats
```

The Unreal docs do not have a corresponding analytics overview page, so no changes are needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)