### PR TITLE
Merge core/v7.1 into unreal/v2.3 (Conflicts)

### DIFF
--- a/docs/cli/guides/getting-started.md
+++ b/docs/cli/guides/getting-started.md
@@ -6,9 +6,9 @@ The Beamable CLI is a dotnet tool that allows developers to interact with Beamab
 You'll need to install [Dotnet 10](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) before you can get started.
 Verify it is installed by running `dotnet --version` from a terminal.
 
-!!! info "Dotnet 8 is also supported."
+!!! info "We support Dotnet 8 as well."
 
-    If you are using the Beamable CLI before version 7.0, then you should be using [Dotnet 8](https://dotnet.microsoft.com/en-us/download/dotnet/8.0). Starting with CLI 7.0 and beyond, both versions of dotnet are supported, but `net10.0` is recommended.
+    If you are using the Beamable CLI before version 7.0, then you should be using [Dotnet 8](https://dotnet.microsoft.com/en-us/download/dotnet/8.0). Starting with CLI 7.0 and beyond, we support both versions of dotnet, but we recommend you use `net10.0`.
 
 ## Installing
 
@@ -56,7 +56,7 @@ dotnet beam config
 ```
 You should expect to see your CID/PID printed out.
 
-As of CLI 3.0.0, anytime you create a Beamable workspace, the CLI will be installed as a local tool next to the workspace's `.beamable/` folder. This means that you can run the local tool with `dotnet beam`. If you continue to use `beam` in the workspace, the global installation will automatically forward your command to the local tool. This will be inefficient and lead to poor performance. Use `dotnet beam` wherever possible.
+As of CLI 3.0.0, anytime you create a Beamable workspace, the CLI will be installed as a local tool next to the workspace's `.beamable/` folder. This means that you can run the local tool with `dotnet beam`. If you continue to use `beam` in the workspace, the global installation will automatically forward your command to the local tool. This will be inefficient and lead to poor performance. We recommend you use `dotnet beam` wherever possible.
 
 To check that everything is working correctly, you can use the beam me command. Now you have a configured CLI project!
 

--- a/docs/cli/guides/ms-command-line.md
+++ b/docs/cli/guides/ms-command-line.md
@@ -78,7 +78,7 @@ cat output.txt
 
 A common workflow is to use the [JQ](https://jqlang.github.io/jq/download/) tool to navigate the piped `--raw` output. Below are some common examples.
 
-To pipe the `data` to a file, you can write:
+In order to pipe the `data` to a file, we could write,
 ```sh
 dotnet beam config | jq '.data' > output.txt
 cat output.txt
@@ -96,7 +96,7 @@ dotnet beam config | jq '.data.cid'
 "123"
 ```
 
-Sometimes it is important to get the unescaped JSON, so the `fromjson` component of JQ can be used. To get the `cid` value without quotes:
+Sometimes it is important to get the unescaped JSON, so the `fromjson` component of JQ can be used. For example, if we wanted the `cid` value, but without quotes,
 
 ```sh
 dotnet beam config | jq '.data.cid | fromjson'

--- a/docs/cli/guides/ms-deployment.md
+++ b/docs/cli/guides/ms-deployment.md
@@ -103,7 +103,7 @@ When planning to release microservices, it is important to think about how to ha
 
 **Merge**: Creates a release plan that merges your current local environment to the existing remote services. In other words, existing deployed services that are not present locally will remain unaffected.
 
-By default, the **replace** plan is used as it keeps "whatever is in your repository" as the source of truth. That being said, there are cases where **merge** can be useful.
+By default, we use the **replace** plan as it keeps "whatever is in your repository" as the source of truth. That being said, there are cases where **merge** can be useful.
 
 For example, in cases where you want to remove the source code of a service from the repo, but still have the service be available for a while; this can happen if you have multiple *supported* client versions in existence, one dependent on a removed service and the other not.
 
@@ -250,7 +250,7 @@ You have full control over the docker-compose file, so if you want to set up per
 
 You can do that by running: `dotnet beam deploy plan --logs v` which prints out all docker commands it is using under the hood. You can then use the printed commands as a starting point for your investigation into whatever problem you're solving.
 
-**Debugging Container Structure**: In some cases of customized `Dockerfiles`, the image may fail to build or the container fail to run due to aspects of the container's file structure. Docker will not allow you to easily inspect a container's file structure unless it is running; and the container is removed once its `ENTRYPOINT` process is killed.
+**Debugging Container Structure**: In some cases of customized `Dockerfiles`, the image may fail to build or the container fail to run due to aspects of the container's file structure. Docker will not allow you to easily inspect a container's file structure unless its running; and we cleanup the container once its `ENTRYPOINT` process is killed.
 
 This means that if SAMS code depends on local file structure (DLLs not existing where they should being the most common thing) and it fails because of a malformation of that structure you'll have a hard time debugging it.
 

--- a/docs/cli/guides/ms-logging.md
+++ b/docs/cli/guides/ms-logging.md
@@ -250,7 +250,7 @@ There are several standard log attributes that will be included automatically. S
 
 Starting with version 6.0, it is possible to send Microservice logs to third parties. This example uses BetterStack.
 
-This section assumes you have set up a BetterStack account and created a _Source_ such that you have a _source token_ and an _ingesting host_.
+This section will assume you have set up a BetterStack account, and created a _Source_ such that you have a _source token_ and an _ingesting host_.
 
 First, configure locally running Microservices to send data to BetterStack. Create a file called `config.yaml` next to your `BeamableServices.sln` file.
 
@@ -308,7 +308,7 @@ docker run -p 4317:4317 -p 4318:4318 \
 	ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.125.0
 ```
 
-Now you have a locally running telemetry collector. Next, configure your local Microservice to _use_ the collector. Prepare the following environment variables:
+Now you have a locally running telemetry collector. We need to configure your local Microservice to _use_ the collector. Prepare the following environment variables,
 
 ```sh
 export BEAM_DISABLE_STANDARD_OTEL=1

--- a/docs/cli/guides/ms-troubleshooting.md
+++ b/docs/cli/guides/ms-troubleshooting.md
@@ -120,7 +120,7 @@ public partial class MyMicroservice : Microservice
 ## Invalid Type Usage in Callable Method
 
 **Explanation**:
-Types used in `[ClientCallable]` methods must be available to both server and client. Declaring types inside the microservice class makes them inaccessible to the Unity client, as the SDK does not regenerate DTOs for the client in that case.
+Types used in `[ClientCallable]` methods must be available to both server and client. Declaring types inside the microservice class makes them inaccessible to the Unity client as we're not regenerating DTO for Client.
 
 **Example Code Triggering the Error**:
 ```csharp

--- a/docs/cli/guides/upgrading.md
+++ b/docs/cli/guides/upgrading.md
@@ -208,7 +208,7 @@ following line to the end of the file.
 ### From 2.0.2 to 3.0.1
 The upgrade from 2.0.x to 3.0.1 brings a few critical updates to the `csproj` file, how the Beam CLI tool is managed, and the version of `dotnet`.
 
-**To start this process, open a terminal and navigate to the directory containing your `.beamable/` folder. All commands are written as though invoked from this directory.**
+**To start this process, let's open a terminal and navigate to the directory containing your `.beamable/` folder. All commands are written as though invoked from this directory.**
 
 ```shell
 # In this file structure...
@@ -304,7 +304,8 @@ In every `csproj` file for **Microservices**, **MicroStorages**, and **Common Li
 </PropertyGroup>
 ```
 
-If the project is targeting `net6.0` or `net7.0`, upgrade the `TargetFramework` to `.net8.0`.
+If the project is targeting `net6.0` or `net7.0`, then, we recommend you
+upgrade the `TargetFramework` to `.net8.0`.
 ```xml
 <PropertyGroup Label="Dotnet Settings">
   <!-- net8.0 is the LTS version until 2026. To update your net version, update the <TargetFramework> when Beamable announces support. -->

--- a/docs/includes/abbreviations.md
+++ b/docs/includes/abbreviations.md
@@ -1,5 +1,4 @@
 *[CID]: customer ID
 *[IAP]: in-app purchases
-*[PIE]: play in editor
 *[PID]: realm identifier
 *[RMT]: real money transaction


### PR DESCRIPTION
The core/v7.1 branch was unable to merge into unreal/v2.3. Please review the changes.