### PR TITLE
Merge core/v7.0 into unity/v5.0 (Conflicts)

### DIFF
--- a/.github/workflows/auto-sync-core.yml
+++ b/.github/workflows/auto-sync-core.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout target branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ matrix.branch }}
           token: ${{ secrets.DOCS_PAT }}
@@ -58,7 +58,7 @@ jobs:
           fi
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         id: create_pr
         if: steps.merge.outputs.status == 'conflict'
         with:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
-# Beamable CLI docs
+# Beamable Unity SDK Documentation
 
 Welcome to the comprehensive documentation for the Beamable Unity SDK! Beamable provides a complete backend-as-a-service platform that enables game developers to build modern multiplayer games with advanced features like live operations, social networking, game economy, analytics, and cloud services—all without the complexity of managing backend infrastructure.
 
-## Supported Unity versions
+## Supported Unity Versions
 
 Beamable supports the last 3 major versions of Unity. Today, that means the Beamable Unity SDK is officially supported on the following versions.
 
@@ -10,7 +10,7 @@ Beamable supports the last 3 major versions of Unity. Today, that means the Beam
 - Unity 2022
 - Unity 6
 
-## Quick start
+## Quick Start
 
 New to Beamable? Get up and running in minutes:
 


### PR DESCRIPTION
The core/v7.0 branch was unable to merge into unity/v5.0. Please review the changes.