### PR TITLE
Merge core/v7.1 into unreal/v2.3 (Conflicts)

### DIFF
--- a/.github/workflows/auto-sync-core.yml
+++ b/.github/workflows/auto-sync-core.yml
@@ -40,8 +40,15 @@ jobs:
         run: |
           git fetch origin ${{ github.ref_name }}
 
+          # Files that legitimately differ between core and downstream branches
+          # (e.g. unity/unreal each have their own top-level nav and landing
+          # page). Restore the target branch's version after every merge so
+          # core's copy never clobbers them.
+          PRESERVE_PATHS="docs/SUMMARY.md docs/index.md"
+
           # Try a normal squash merge
           if git merge origin/${{ github.ref_name }} --squash; then
+                git checkout HEAD -- $PRESERVE_PATHS 2>/dev/null || true
                 if ! git diff --cached --quiet; then
                   git commit -m "Squash merge ${{ github.ref_name }} into ${{ matrix.branch }}"
                   git push origin ${{ matrix.branch }}
@@ -51,7 +58,8 @@ jobs:
               # Merge conflict: retry with 'theirs'
               git reset --hard HEAD
               git merge origin/${{ github.ref_name }} --squash -X theirs
-              if ! git diff --quiet; then
+              git checkout HEAD -- $PRESERVE_PATHS 2>/dev/null || true
+              if ! git diff --cached --quiet; then
                   git commit -m "Squash merge ${{ github.ref_name }} into ${{ matrix.branch }}"
               fi
               echo "status=conflict" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The core/v7.1 branch was unable to merge into unreal/v2.3. Please review the changes.